### PR TITLE
feat: add minimal mode to hide icons across sections

### DIFF
--- a/app/components/Contact.vue
+++ b/app/components/Contact.vue
@@ -11,6 +11,7 @@
         class="flex items-center gap-2 group"
       >
         <UIcon
+          v-if="!isMinimalMode"
           :name="item.icon"
           class="text-gray-700 dark:text-gray-300 w-6 h-6 transition-all duration-500 group-hover:scale-110"
         />
@@ -30,4 +31,5 @@ const { data: contactData } = await useAsyncData("contact", () =>
 );
 
 const items = computed(() => contactData.value?.contact || []);
+const isMinimalMode = useMinimalMode()
 </script>

--- a/app/components/blog/Card.vue
+++ b/app/components/blog/Card.vue
@@ -8,6 +8,7 @@
     </span>
     <div class="flex items-center gap-2">
       <UAvatar
+        v-if="!isMinimalMode"
         :src="article.thumbnail"
         :ui="{ rounded: 'rounded relative bg-gray-700' }"
         :alt="article.title"
@@ -39,4 +40,6 @@ onMounted(() => {
     "Do MMMM YYYY"
   ).value;
 });
+
+const isMinimalMode = useMinimalMode()
 </script>

--- a/app/components/content/Announcement.vue
+++ b/app/components/content/Announcement.vue
@@ -5,10 +5,7 @@
       :description="description"
       color="neutral"
       variant="subtle"
-      :avatar="{
-        src: image,
-        alt: title,
-      }"
+      :avatar="isMinimalMode ? undefined : { src: image, alt: title }"
     />
   </a>
 </template>
@@ -32,5 +29,7 @@ defineProps({
     required: true,
   },
 });
+
+const isMinimalMode = useMinimalMode()
 </script>
 

--- a/app/components/project/Card.vue
+++ b/app/components/project/Card.vue
@@ -6,6 +6,7 @@
     external
   >
     <UChip
+      v-if="!isMinimalMode"
       :color="STATUS_COLORS[project.status]"
       size="md"
       variant="solid"
@@ -45,4 +46,6 @@ defineProps({
     required: true,
   },
 });
+
+const isMinimalMode = useMinimalMode()
 </script>

--- a/app/components/shared/footer.vue
+++ b/app/components/shared/footer.vue
@@ -7,7 +7,7 @@
         color="neutral"
         variant="subtle"
         :title="footer.affiliate.title"
-        :avatar="{ src: '/credits/dubco.png', alt: 'Dub.co', size: 'sm' }"
+        :avatar="isMinimalMode ? undefined : { src: '/credits/dubco.png', alt: 'Dub.co', size: 'sm' }"
       >
         <template #title="{ title }">
           <h2 class="text-lg font-bold">{{ title }}</h2>
@@ -36,7 +36,7 @@
       <!-- Github repo -->
       <UAlert
         v-if="footer"
-        icon="i-simple-icons-github"
+        :icon="isMinimalMode ? undefined : 'i-simple-icons-github'"
         color="neutral"
         variant="subtle"
         :title="footer.title"
@@ -93,6 +93,8 @@ const config = useRuntimeConfig();
 const { data: footer } = await useAsyncData("footer", () => {
   return queryCollection("footer").first();
 });
+
+const isMinimalMode = useMinimalMode()
 </script>
 <style scoped>
 @reference "~/assets/css/main.css";

--- a/app/composables/useMinimalMode.ts
+++ b/app/composables/useMinimalMode.ts
@@ -1,0 +1,4 @@
+export const useMinimalMode = () => {
+  const config = useRuntimeConfig()
+  return computed(() => config.public.minimalMode as boolean)
+}

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -101,6 +101,7 @@ export default defineNuxtConfig({
 
   runtimeConfig: {
     public: {
+      minimalMode: process.env.NUXT_PUBLIC_MINIMAL_MODE === "true",
       statusSiteSlug: process.env.STATUS_SITE_SLUG,
       baseURL: process.env.NUXT_PUBLIC_SITE_URL,
       ownerName: process.env.OWNER_NAME,


### PR DESCRIPTION
## Summary
- Adds `NUXT_PUBLIC_MINIMAL_MODE` env flag (boolean) to toggle minimal mode
- When enabled, hides all icons/thumbnails in Links, Projects, Announcements, Blog, and footer banners
- New `useMinimalMode()` composable reads the flag from `runtimeConfig.public`

## Components updated
- `Contact.vue` — hides link icons
- `project/Card.vue` — hides project thumbnails (UChip + UAvatar)
- `content/Announcement.vue` — hides announcement avatar
- `blog/Card.vue` — hides blog thumbnails
- `shared/footer.vue` — hides affiliate avatar and GitHub icon in footer banners

## Test plan
- [x] Set `NUXT_PUBLIC_MINIMAL_MODE=true` and verify all icons are hidden in the above sections
- [ ] Set `NUXT_PUBLIC_MINIMAL_MODE=false` and verify icons render normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)