### PR TITLE
fix: use none image provider to fix broken thumbnails on Vercel

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -60,6 +60,10 @@ export default defineNuxtConfig({
     },
   },
 
+  image: {
+    provider: "none",
+  },
+
   routeRules: {
     "/": { prerender: true },
     "/uses": { prerender: true },


### PR DESCRIPTION
## Summary

- All project logo and blog post thumbnails were returning 404 via `/_ipx/s_64x64/...` URLs
- The IPX server handler is not deployed on Vercel, so those routes never existed
- Setting `image.provider = "none"` makes `@nuxt/image` pass original static file paths through unchanged (e.g. `/projects/logo/rss-herald.svg`)

## Test plan

- [ ] Visit akshara.dev after deploy — project logos and blog thumbnails should load
- [ ] Check browser network tab: no more `/_ipx/` requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)