### PR TITLE
fix: use none image provider to fix broken thumbnails on Vercel

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -60,6 +60,10 @@ export default defineNuxtConfig({
     },
   },
 
+  image: {
+    provider: "none",
+  },
+
   routeRules: {
     "/": { prerender: true },
     "/uses": { prerender: true },


### PR DESCRIPTION
The /_ipx/ server handler is not deployed on Vercel, causing all UAvatar thumbnails (project logos, blog post images) to 404. Setting provider to "none" passes the original static file URLs through unchanged.