### PR TITLE
feat(certifications): add homepage section and archive page

### DIFF
--- a/app/components/certification/Card.vue
+++ b/app/components/certification/Card.vue
@@ -1,0 +1,141 @@
+<template>
+  <NuxtLink
+    v-if="variant === 'compact'"
+    :to="certification.url"
+    :data-testid="`${testDomain}-row-${rowId}`"
+    target="_blank"
+    external
+    class="group grid gap-3 border-t border-zinc-200 py-3 text-[12px] transition hover:bg-white/40 dark:border-zinc-800 dark:hover:bg-white/5 md:grid-cols-[minmax(0,1fr)_24px] md:items-center"
+  >
+    <div class="flex min-w-0 items-center gap-3">
+      <UAvatar
+        v-if="certification.badge"
+        :src="certification.badge"
+        :ui="{ rounded: 'rounded px-[2px] py-[4px] relative' }"
+        :alt="certification.heading"
+        :class="certification.badgeBg"
+        size="sm"
+      />
+      <div
+        v-else-if="certification.icon"
+        class="flex size-8 shrink-0 items-center justify-center rounded bg-zinc-100 dark:bg-zinc-800"
+      >
+        <UIcon :name="certification.icon" class="size-4 text-zinc-700 dark:text-zinc-300" />
+      </div>
+      <div class="min-w-0">
+        <h3 class="truncate font-semibold text-zinc-950 dark:text-zinc-50">
+          {{ certification.heading }}
+        </h3>
+        <p class="line-clamp-1 text-zinc-500 dark:text-zinc-400">
+          {{ issuerLine }}
+        </p>
+      </div>
+    </div>
+
+    <UIcon
+      name="i-solar-arrow-right-up-linear"
+      class="hidden size-4 justify-self-end text-zinc-400 transition group-hover:translate-x-0.5 group-hover:-translate-y-0.5 group-hover:text-zinc-900 md:block dark:group-hover:text-white"
+    />
+  </NuxtLink>
+
+  <NuxtLink
+    v-else
+    :to="certification.url"
+    :data-testid="`${testDomain}-row-${rowId}`"
+    target="_blank"
+    external
+    class="group grid gap-4 border-t border-zinc-200 py-5 text-[12px] transition hover:bg-white/40 dark:border-zinc-800 dark:hover:bg-white/5 md:grid-cols-[minmax(0,1fr)_24px] md:items-start"
+  >
+    <div class="flex min-w-0 gap-3">
+      <UAvatar
+        v-if="certification.badge"
+        :src="certification.badge"
+        :ui="{ rounded: 'rounded px-[2px] py-[4px] relative' }"
+        :alt="certification.heading"
+        :class="certification.badgeBg"
+        size="sm"
+      />
+      <div
+        v-else-if="certification.icon"
+        class="flex size-8 shrink-0 items-center justify-center rounded bg-zinc-100 dark:bg-zinc-800"
+      >
+        <UIcon :name="certification.icon" class="size-4 text-zinc-700 dark:text-zinc-300" />
+      </div>
+      <div class="min-w-0">
+        <div class="flex flex-wrap items-center gap-2">
+          <h3 class="text-xl font-semibold tracking-[-0.04em] text-zinc-950 transition group-hover:text-primary-600 dark:text-zinc-50 dark:group-hover:text-primary-500">
+            {{ certification.heading }}
+          </h3>
+          <span
+            v-if="issuedDate"
+            class="text-[10px] font-semibold uppercase tracking-[0.16em] text-zinc-500 dark:text-zinc-400"
+          >
+            {{ issuedDate }}
+          </span>
+        </div>
+        <p class="mt-1 text-zinc-600 dark:text-zinc-400">
+          {{ issuerLine }}
+        </p>
+        <p
+          v-if="certification.description"
+          class="mt-1 line-clamp-2 leading-6 text-zinc-600 dark:text-zinc-400"
+        >
+          {{ certification.description }}
+        </p>
+        <p
+          v-if="certification.credentialId"
+          class="mt-2 text-[10px] font-medium uppercase tracking-[0.14em] text-zinc-500 dark:text-zinc-400"
+        >
+          ID {{ certification.credentialId }}
+        </p>
+      </div>
+    </div>
+
+    <UIcon
+      name="i-solar-arrow-right-up-linear"
+      class="hidden size-4 justify-self-end text-zinc-400 transition group-hover:translate-x-0.5 group-hover:-translate-y-0.5 group-hover:text-zinc-900 md:block dark:group-hover:text-white"
+    />
+  </NuxtLink>
+</template>
+
+<script setup>
+import { useDateFormat } from "@vueuse/core";
+
+const props = defineProps({
+  certification: {
+    type: Object,
+    required: true,
+  },
+  variant: {
+    type: String,
+    default: "compact",
+  },
+  testDomain: {
+    type: String,
+    default: "portfolio-certifications",
+  },
+});
+
+const testDomain = computed(() => props.testDomain);
+const rowId = computed(() =>
+  String(props.certification?.heading || "certification")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/(^-|-$)/g, "")
+);
+
+const issuedDate = computed(() =>
+  props.certification?.issued
+    ? useDateFormat(props.certification.issued, "MMM YYYY").value
+    : ""
+);
+
+const issuerLine = computed(() => {
+  if (props.variant === "compact") {
+    const parts = [props.certification?.issuer, issuedDate.value].filter(Boolean);
+    return parts.join(" · ");
+  }
+
+  return props.certification?.issuer || "";
+});
+</script>

--- a/app/pages/certifications.vue
+++ b/app/pages/certifications.vue
@@ -1,0 +1,79 @@
+<template>
+  <main class="min-h-screen pb-12">
+    <section class="space-y-8 pb-12 pt-6 md:pb-16 md:pt-8">
+      <div>
+        <p class="text-[11px] font-semibold uppercase tracking-[0.18em] text-zinc-700 dark:text-zinc-300">
+          Credentials
+        </p>
+        <h1 class="mt-3 font-serif text-3xl leading-none tracking-[-0.06em] text-zinc-950 dark:text-zinc-50 sm:text-4xl md:text-4xl">
+          {{ pageDoc.title }}
+        </h1>
+        <p class="mt-4 max-w-xl text-[15px] leading-7 text-zinc-700 dark:text-zinc-300">
+          {{ pageDoc.description }}
+        </p>
+        <p class="mt-5 text-[10px] font-semibold uppercase tracking-[0.18em] text-zinc-500 dark:text-zinc-400">
+          {{ certificationItems.length }} certifications
+        </p>
+      </div>
+    </section>
+
+    <section>
+      <div class="mb-4">
+        <h2 class="font-serif text-2xl tracking-[-0.04em] text-zinc-950 dark:text-zinc-50">
+          All Certifications
+        </h2>
+      </div>
+
+      <CertificationCard
+        v-for="certification in certificationItems"
+        :key="certification.heading"
+        :certification="certification"
+        variant="archive"
+        test-domain="portfolio-certifications"
+      />
+    </section>
+  </main>
+</template>
+
+<script setup>
+const route = useRoute();
+const config = useRuntimeConfig();
+
+const { data: certifications } = await useAsyncData("certifications-all", () =>
+  queryCollection("certifications").order("issued", "DESC").all()
+);
+
+const { data: doc } = await useAsyncData("certifications-index", () =>
+  queryCollection("certifications").where("title", "==", "Certifications").first()
+);
+
+const pageDoc = computed(() => ({
+  title: "Certifications",
+  description: "Professional credentials and course completions.",
+  icon: "solar:diploma-verified-linear",
+  ...(doc.value || {}),
+}));
+
+const certificationItems = computed(() =>
+  (certifications.value || []).filter((item) => item?.heading && item?.url)
+);
+
+const { title, description, icon } = pageDoc.value;
+defineOgImage("MyOg", {
+  headline: config.public.ownerName,
+  title,
+  description,
+  icon,
+  url: route.fullPath,
+});
+
+useSeoMeta({
+  title,
+  description,
+  ogTitle: title,
+  ogDescription: description,
+  twitterTitle: title,
+  twitterDescription: description,
+  twitterImage: `${config.public.baseURL}/og_me.png`,
+});
+</script>

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -88,6 +88,26 @@
         />
       </div>
 
+      <div v-if="recentCertifications.length">
+        <div class="mb-4 grid grid-cols-[1fr_auto] items-center gap-4">
+          <h2 class="font-serif text-2xl tracking-[-0.04em] text-zinc-950 dark:text-zinc-50">Certifications</h2>
+          <NuxtLink
+            to="/certifications"
+            data-testid="portfolio-certifications-view-link"
+            class="text-[11px] text-zinc-700 transition hover:text-zinc-950 dark:text-zinc-300 dark:hover:text-white"
+          >
+            View all certifications →
+          </NuxtLink>
+        </div>
+        <CertificationCard
+          v-for="certification in recentCertifications"
+          :key="certification.heading"
+          :certification="certification"
+          variant="compact"
+          test-domain="portfolio-certifications"
+        />
+      </div>
+
       <div>
         <div class="mb-4 grid grid-cols-[1fr_auto] items-center gap-4">
           <h2 class="font-serif text-2xl tracking-[-0.04em] text-zinc-950 dark:text-zinc-50">Developer Toolkit</h2>
@@ -145,6 +165,10 @@ const { data: articles } = await useAsyncData("home-writing", () =>
     .all()
 );
 
+const { data: certifications } = await useAsyncData("home-certifications", () =>
+  queryCollection("certifications").order("issued", "DESC").all()
+);
+
 const { data: seo } = await useAsyncData("seo", () =>
   queryCollection("seo").first()
 );
@@ -183,6 +207,11 @@ const experimentItems = computed(() =>
 );
 const toolkitItems = computed(() =>
   homeContent.value.toolkit.filter((item) => item?.id && item?.title)
+);
+const recentCertifications = computed(() =>
+  (certifications.value || [])
+    .filter((item) => item?.heading && item?.url)
+    .slice(0, 4)
 );
 
 const payload = {

--- a/content.config.ts
+++ b/content.config.ts
@@ -171,5 +171,21 @@ export default defineContentConfig({
         ),
       }),
     }),
+    certifications: defineCollection({
+      type: "data",
+      source: "certifications/*.json",
+      schema: z.object({
+        title: z.string().optional(),
+        description: z.string().optional(),
+        icon: z.string().optional(),
+        heading: z.string().optional(),
+        issuer: z.string().optional(),
+        issued: z.string().optional(),
+        credentialId: z.string().optional(),
+        url: z.string().optional(),
+        badge: z.string().optional(),
+        badgeBg: z.string().optional(),
+      }),
+    }),
   },
 });

--- a/content/certifications/01.building-with-claude-api.json
+++ b/content/certifications/01.building-with-claude-api.json
@@ -1,0 +1,11 @@
+{
+  "heading": "Building with the Claude API",
+  "issuer": "Anthropic",
+  "issued": "2026-04-01",
+  "description": "Foundations for building applications with the Claude API.",
+  "credentialId": "7nsjj59cuez4",
+  "url": "https://verify.skilljar.com/c/7nsjj59cuez4",
+  "badge": "/certifications/claude.svg",
+  "badgeBg": "bg-amber-100 dark:bg-amber-950",
+  "icon": "i-simple-icons-anthropic"
+}

--- a/content/certifications/02.claude-code-in-action.json
+++ b/content/certifications/02.claude-code-in-action.json
@@ -1,0 +1,11 @@
+{
+  "heading": "Claude Code in Action",
+  "issuer": "Anthropic",
+  "issued": "2026-04-08",
+  "description": "Hands-on workflows for shipping with Claude Code.",
+  "credentialId": "y3tvhfi8v74k",
+  "url": "https://verify.skilljar.com/c/y3tvhfi8v74k",
+  "badge": "/certifications/claude.svg",
+  "badgeBg": "bg-amber-100 dark:bg-amber-950",
+  "icon": "i-simple-icons-anthropic"
+}

--- a/content/certifications/03.introduction-to-agent-skills.json
+++ b/content/certifications/03.introduction-to-agent-skills.json
@@ -1,0 +1,11 @@
+{
+  "heading": "Introduction to Agent Skills",
+  "issuer": "Anthropic",
+  "issued": "2026-04-15",
+  "description": "Core concepts for designing and using agent skills.",
+  "credentialId": "sh3rkgi669ci",
+  "url": "https://verify.skilljar.com/c/sh3rkgi669ci",
+  "badge": "/certifications/claude.svg",
+  "badgeBg": "bg-amber-100 dark:bg-amber-950",
+  "icon": "i-simple-icons-anthropic"
+}

--- a/content/certifications/04.introduction-to-mcp.json
+++ b/content/certifications/04.introduction-to-mcp.json
@@ -1,0 +1,11 @@
+{
+  "heading": "Introduction to Model Context Protocol",
+  "issuer": "Anthropic",
+  "issued": "2026-04-22",
+  "description": "Getting started with MCP for tool-connected AI workflows.",
+  "credentialId": "3mxgx8yiryog",
+  "url": "https://verify.skilljar.com/c/3mxgx8yiryog",
+  "badge": "/certifications/claude.svg",
+  "badgeBg": "bg-amber-100 dark:bg-amber-950",
+  "icon": "i-simple-icons-anthropic"
+}

--- a/content/certifications/05.claude-code-101.json
+++ b/content/certifications/05.claude-code-101.json
@@ -1,0 +1,11 @@
+{
+  "heading": "Claude Code 101",
+  "issuer": "Anthropic",
+  "issued": "2026-07-01",
+  "description": "Essentials for working effectively with Claude Code.",
+  "credentialId": "5v4rrw6egim7",
+  "url": "https://verify.skilljar.com/c/5v4rrw6egim7",
+  "badge": "/certifications/claude.svg",
+  "badgeBg": "bg-amber-100 dark:bg-amber-950",
+  "icon": "i-simple-icons-anthropic"
+}

--- a/content/certifications/index.json
+++ b/content/certifications/index.json
@@ -1,0 +1,5 @@
+{
+  "title": "Certifications",
+  "description": "Professional credentials and course completions from AI platforms and developer programs.",
+  "icon": "solar:diploma-verified-linear"
+}

--- a/public/certifications/README.md
+++ b/public/certifications/README.md
@@ -1,0 +1,3 @@
+# Certification badges
+
+Replace `claude.svg` with an official Anthropic badge image, or update `badge` paths in `content/certifications/*.json`.

--- a/public/certifications/claude.svg
+++ b/public/certifications/claude.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
+  <rect width="32" height="32" rx="6" fill="#D97757"/>
+  <path d="M16 8c-2.5 3.5-5 5.5-5 9a5 5 0 0 0 10 0c0-3.5-2.5-5.5-5-9z" fill="#fafafa" opacity="0.95"/>
+</svg>

--- a/public/certifications/cursor.svg
+++ b/public/certifications/cursor.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
+  <rect width="32" height="32" rx="6" fill="#171717"/>
+  <path d="M8 10h16v2H8V10zm0 5h12v2H8v-2zm0 5h14v2H8v-2z" fill="#fafafa"/>
+</svg>


### PR DESCRIPTION
## Summary
- Add a JSON-backed `certifications` content collection with five Anthropic credentials
- Show up to four recent certifications on the homepage with external Skilljar verification links
- Add a dedicated `/certifications` archive page (no navbar link)

## Test plan
- [ ] Homepage shows four most recent certifications after Writing
- [ ] "View all certifications →" opens `/certifications`
- [ ] Each cert row opens the correct `verify.skilljar.com` URL
- [ ] Navbar remains unchanged

Made with [Cursor](https://cursor.com)