### PR TITLE
Reorder social links to surface Cal.com earlier

### DIFF
--- a/content/contact.json
+++ b/content/contact.json
@@ -3,9 +3,9 @@
     { "name": "Github", "icon": "i-simple-icons-github", "url": "https://git.new/pahachaan" },
     { "name": "LinkedIn", "icon": "i-simple-icons-linkedin", "url": "https://linkedin.com/in/aksharadt" },
     { "name": "Twitter", "icon": "i-simple-icons-x", "url": "https://x.com/akshara_dev" },
-    { "name": "PRs", "icon": "i-solar-usb-bold", "url": "http://prs.akshara.dev" },
+    { "name": "Cal.com", "icon": "i-solar-calendar-date-bold", "url": "https://cal.com/aksharahegde" },
     { "name": "Email", "icon": "i-simple-icons-minutemailer", "url": "mailto:akshara.dt@gmail.com" },
     { "name": "Peerlist", "icon": "i-simple-icons-peerlist", "url": "https://peerlist.io/akshara" },
-    { "name": "Cal.com", "icon": "i-solar-calendar-date-bold", "url": "https://cal.com/aksharahegde" }
+    { "name": "PRs", "icon": "i-solar-usb-bold", "url": "http://prs.akshara.dev" }
   ]
 }


### PR DESCRIPTION
## Summary
- Move Cal.com into the slot previously occupied by PRs on the homepage social links
- Move PRs to the end of the contact list

## Test plan
- [x] Open homepage and confirm Cal.com appears as the 4th social link (after Twitter)
- [x] Confirm PRs appears last in the social links list
- [x] Verify all links still navigate to the correct destinations


Made with [Cursor](https://cursor.com)