### PR TITLE
Add mobile bottom navigation

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -10,7 +10,8 @@
     <div class="h-12 md:h-20" />
     <SharedVisitors class="no-print" />
     <SharedFooter class="no-print" />
-    <div class="h-8 md:hidden" />
+    <SharedMobileBottomNav class="no-print" />
+    <div class="h-[calc(4rem+env(safe-area-inset-bottom))] md:h-0" />
   </UApp>
 </template>
 <script setup lang="ts">

--- a/app/components/shared/MobileBottomNav.vue
+++ b/app/components/shared/MobileBottomNav.vue
@@ -1,0 +1,106 @@
+<template>
+  <nav
+    aria-label="Mobile navigation"
+    class="fixed inset-x-0 bottom-0 z-50 border-t border-zinc-200/70 bg-white/90 backdrop-blur md:hidden dark:border-zinc-800 dark:bg-zinc-950/90"
+  >
+    <ul class="flex items-stretch justify-around pb-[env(safe-area-inset-bottom)]">
+      <li
+        v-for="item in primaryMobileNav"
+        :key="item.to"
+        class="flex min-w-0 flex-1"
+      >
+        <NuxtLink
+          :to="item.to"
+          :data-testid="item.testId"
+          class="flex min-h-11 w-full flex-col items-center justify-center gap-0.5 px-1 py-2 text-[10px] font-medium transition"
+          :class="
+            isNavItemActive(route.path, item.to)
+              ? 'text-zinc-950 dark:text-white'
+              : 'text-zinc-500 dark:text-zinc-400'
+          "
+        >
+          <UIcon :name="item.icon" class="size-5" />
+          <span>{{ item.label }}</span>
+        </NuxtLink>
+      </li>
+
+      <li class="flex min-w-0 flex-1">
+        <button
+          type="button"
+          data-testid="portfolio-bottom-nav-more-trigger"
+          class="flex min-h-11 w-full flex-col items-center justify-center gap-0.5 px-1 py-2 text-[10px] font-medium transition"
+          :class="
+            isMoreOpen || isMoreNavActive(route.path)
+              ? 'text-zinc-950 dark:text-white'
+              : 'text-zinc-500 dark:text-zinc-400'
+          "
+          @click="isMoreOpen = true"
+        >
+          <UIcon name="i-solar-menu-dots-linear" class="size-5" />
+          <span>More</span>
+        </button>
+      </li>
+    </ul>
+
+    <ClientOnly>
+      <UDrawer
+        v-model:open="isMoreOpen"
+        :handle="true"
+        :should-scale-background="false"
+        :ui="moreDrawerUi"
+      >
+        <template #body>
+          <p class="mb-3 text-sm font-semibold text-zinc-950 dark:text-white">
+            More
+          </p>
+          <ul class="flex flex-col gap-1">
+            <li v-for="item in moreMobileNav" :key="item.to">
+              <NuxtLink
+                :to="item.to"
+                :data-testid="item.testId"
+                class="flex items-center gap-3 rounded-lg px-3 py-3 text-sm font-medium transition hover:bg-zinc-100 dark:hover:bg-zinc-800"
+                :class="
+                  isNavItemActive(route.path, item.to)
+                    ? 'text-zinc-950 dark:text-white'
+                    : 'text-zinc-700 dark:text-zinc-300'
+                "
+                @click="isMoreOpen = false"
+              >
+                <UIcon :name="item.icon" class="size-5 shrink-0" />
+                <span>{{ item.label }}</span>
+              </NuxtLink>
+            </li>
+          </ul>
+        </template>
+      </UDrawer>
+    </ClientOnly>
+  </nav>
+</template>
+
+<script setup lang="ts">
+import {
+  isMoreNavActive,
+  isNavItemActive,
+  moreMobileNav,
+  primaryMobileNav,
+} from "~/constants/siteNav";
+
+const route = useRoute();
+const isMoreOpen = ref(false);
+
+const moreDrawerUi = {
+  overlay: "bg-zinc-950/50",
+  content:
+    "bg-white dark:bg-zinc-950 border-t border-zinc-200/70 dark:border-zinc-800 ring-0 focus:outline-none",
+  handle: "!bg-zinc-300 dark:!bg-zinc-600",
+  container: "p-4 pb-[calc(1rem+env(safe-area-inset-bottom))]",
+  body: "px-1",
+};
+
+watch(
+  () => route.path,
+  () => {
+    isMoreOpen.value = false;
+  },
+);
+</script>

--- a/app/components/shared/navbar.vue
+++ b/app/components/shared/navbar.vue
@@ -10,54 +10,14 @@
       </NuxtLink>
 
       <ul class="hidden items-center gap-8 text-zinc-700 dark:text-zinc-300 md:flex">
-        <li>
+        <li v-for="item in desktopNav" :key="item.to">
           <ULink
-            to="/projects"
-            data-testid="portfolio-work-nav-link"
+            :to="item.to"
+            :data-testid="item.testId"
             class="transition hover:text-zinc-950 dark:hover:text-white"
             active-class="text-zinc-950 dark:text-white"
           >
-            Work
-          </ULink>
-        </li>
-        <li>
-          <ULink
-            to="/blog"
-            data-testid="portfolio-writing-nav-link"
-            class="transition hover:text-zinc-950 dark:hover:text-white"
-            active-class="text-zinc-950 dark:text-white"
-          >
-            Writing
-          </ULink>
-        </li>
-        <li>
-          <ULink
-            to="/resources"
-            data-testid="portfolio-toolkit-nav-link"
-            class="transition hover:text-zinc-950 dark:hover:text-white"
-            active-class="text-zinc-950 dark:text-white"
-          >
-            Resources
-          </ULink>
-        </li>
-        <li>
-          <ULink
-            to="/photos"
-            data-testid="portfolio-photos-nav-link"
-            class="transition hover:text-zinc-950 dark:hover:text-white"
-            active-class="text-zinc-950 dark:text-white"
-          >
-            Photos
-          </ULink>
-        </li>
-        <li>
-          <ULink
-            to="/uses"
-            data-testid="portfolio-about-nav-link"
-            class="transition hover:text-zinc-950 dark:hover:text-white"
-            active-class="text-zinc-950 dark:text-white"
-          >
-            Uses
+            {{ item.label }}
           </ULink>
         </li>
       </ul>
@@ -80,5 +40,7 @@
 </template>
 
 <script setup lang="ts">
+import { desktopNav } from "~/constants/siteNav";
+
 const { openCommandPalette } = useCommandPalette();
 </script>

--- a/app/constants/siteNav.ts
+++ b/app/constants/siteNav.ts
@@ -1,0 +1,105 @@
+export type SiteNavItem = {
+  label: string;
+  to: string;
+  icon: string;
+  testId: string;
+};
+
+export const desktopNav: SiteNavItem[] = [
+  {
+    label: "Work",
+    to: "/projects",
+    icon: "i-solar-code-square-linear",
+    testId: "portfolio-work-nav-link",
+  },
+  {
+    label: "Writing",
+    to: "/blog",
+    icon: "i-solar-document-text-linear",
+    testId: "portfolio-writing-nav-link",
+  },
+  {
+    label: "Resources",
+    to: "/resources",
+    icon: "i-solar-bookmark-linear",
+    testId: "portfolio-toolkit-nav-link",
+  },
+  {
+    label: "Photos",
+    to: "/photos",
+    icon: "i-solar-gallery-wide-linear",
+    testId: "portfolio-photos-nav-link",
+  },
+  {
+    label: "Uses",
+    to: "/uses",
+    icon: "i-solar-monitor-linear",
+    testId: "portfolio-about-nav-link",
+  },
+];
+
+export const primaryMobileNav: SiteNavItem[] = [
+  {
+    label: "Work",
+    to: "/projects",
+    icon: "i-solar-code-square-linear",
+    testId: "portfolio-bottom-nav-work-link",
+  },
+  {
+    label: "Writing",
+    to: "/blog",
+    icon: "i-solar-document-text-linear",
+    testId: "portfolio-bottom-nav-writing-link",
+  },
+  {
+    label: "Resources",
+    to: "/resources",
+    icon: "i-solar-bookmark-linear",
+    testId: "portfolio-bottom-nav-resources-link",
+  },
+  {
+    label: "Photos",
+    to: "/photos",
+    icon: "i-solar-gallery-wide-linear",
+    testId: "portfolio-bottom-nav-photos-link",
+  },
+];
+
+export const moreMobileNav: SiteNavItem[] = [
+  {
+    label: "Home",
+    to: "/",
+    icon: "i-solar-home-2-linear",
+    testId: "portfolio-bottom-nav-more-home-link",
+  },
+  {
+    label: "Uses",
+    to: "/uses",
+    icon: "i-solar-monitor-linear",
+    testId: "portfolio-bottom-nav-more-uses-link",
+  },
+  {
+    label: "Labs",
+    to: "/labs",
+    icon: "i-solar-test-tube-linear",
+    testId: "portfolio-bottom-nav-more-labs-link",
+  },
+  {
+    label: "Visitors",
+    to: "/visitors",
+    icon: "i-solar-global-linear",
+    testId: "portfolio-bottom-nav-more-visitors-link",
+  },
+];
+
+export function isNavItemActive(path: string, to: string): boolean {
+  if (to === "/") {
+    return path === "/";
+  }
+
+  return path === to || path.startsWith(`${to}/`);
+}
+
+export function isMoreNavActive(path: string): boolean {
+  return moreMobileNav.some((item) => isNavItemActive(path, item.to));
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pahachaan",
-  "version": "2.4.3",
+  "version": "2.4.4",
   "packageManager": "bun@1.3.6",
   "author": "aksharahegde <https://github.com/aksharahegde>",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Add a fixed bottom tab bar on viewports below 768px with Work, Writing, Resources, Photos, and More
- More opens a zinc-themed drawer for Home, Uses, Labs, and Visitors
- Extract shared nav config into `app/constants/siteNav.ts` and refactor desktop navbar to use it

## Test plan
- [ ] Resize to < 768px and confirm bottom tab bar is visible
- [ ] Tap each primary tab and verify navigation + active state
- [ ] Open More drawer and confirm zinc styling (no blue theme bleed)
- [ ] Confirm desktop nav unchanged at >= 768px
- [ ] Verify visitor badge clears the bottom bar


Made with [Cursor](https://cursor.com)