### PR TITLE
fix(uses): surface setup cover image from content meta

### DIFF
--- a/app/pages/uses.vue
+++ b/app/pages/uses.vue
@@ -89,6 +89,7 @@ const pageMeta = computed(() => ({
   description: "Tools, services, and setup I use.",
   icon: "solar:monitor-smartphone-outline",
   ...(doc.value || {}),
+  ...(doc.value?.meta || {}),
 }));
 
 const coreStack = [

--- a/app/pages/uses.vue
+++ b/app/pages/uses.vue
@@ -11,13 +11,14 @@
         <p class="mt-7 max-w-xl text-[15px] leading-7 text-zinc-700 dark:text-zinc-300">
           {{ pageMeta.description }}
         </p>
-        <img
-          v-if="pageMeta.cover"
-          :src="pageMeta.cover"
-          alt="Workspace development environment"
-          class="mt-7 w-full rounded-lg border border-zinc-200 dark:border-zinc-800"
-        >
       </div>
+
+      <img
+        v-if="pageMeta.cover"
+        :src="pageMeta.cover"
+        alt="Workspace development environment"
+        class="w-full rounded-lg border border-zinc-200 dark:border-zinc-800"
+      >
 
       <aside>
         <h2 class="mb-4 text-[11px] font-semibold uppercase tracking-[0.18em] text-zinc-950 dark:text-zinc-50">

--- a/content.config.ts
+++ b/content.config.ts
@@ -87,6 +87,9 @@ export default defineContentConfig({
       schema: z.object({
         title: z.string(),
         path: z.string(),
+        description: z.string().optional(),
+        icon: z.string().optional(),
+        cover: z.string().optional(),
       }),
     }),
     footer: defineCollection({


### PR DESCRIPTION
## Summary
- Merge `doc.meta` into `pageMeta` on the Uses page so `cover: /uses.png` is available for the workspace image and OG tags.
- Add `description`, `icon`, and `cover` to the root `content` collection schema.

## Test plan
- [ ] Open `/uses` and confirm the workspace setup PNG appears below the page description.
- [ ] Confirm `https://akshara.dev/uses.png` still loads (200).
- [ ] Check OG/social preview uses the setup image instead of the generic fallback.


Made with [Cursor](https://cursor.com)